### PR TITLE
site title is hidden in customizer when no logo is set

### DIFF
--- a/assets/js/customize-preview.js
+++ b/assets/js/customize-preview.js
@@ -36,11 +36,15 @@ swapImgToSvg('.custom-logo-link img');
     // Collect information from customize-controls.js about which panels are opening.
 
     // Site title and description.
-    wp.customize('blogname', function (value) {
-        value.bind(function (to) {
-            $('.site-title a').text(to);
-        });
-    });
+    wp.customize( 'blogname', function( value ) {
+
+        // If logo isn't set then bind site-title for live update.
+        if ( ! parent.wp.customize( 'custom_logo' )() ) {
+            value.bind( function( to ) {
+                $( '.site-title a' ).text( to );
+            } );
+        }
+    } );
 
     wp.customize('blogdescription', function (value) {
 

--- a/assets/sass/_menus.scss
+++ b/assets/sass/_menus.scss
@@ -51,10 +51,6 @@ body .site-logo {
 /*--------------------------------------------------------------
 ## Logo and menu positions from WP Customizer
 --------------------------------------------------------------*/
-.custom-logo-link + .site-title{
-  display: none;
-}
-
 //no logo. Center menu and hide logo on customizer. Elsewhere no logo will even show.
 .no-logo > .site-logo {
 	display: none;

--- a/style.css
+++ b/style.css
@@ -777,9 +777,6 @@ body .site-logo {
 /*--------------------------------------------------------------
 ## Logo and menu positions from WP Customizer
 --------------------------------------------------------------*/
-.custom-logo-link + .site-title {
-  display: none; }
-
 .no-logo > .site-logo {
   display: none; }
 


### PR DESCRIPTION
The site title was not displaying if I didn't set a logo in the customizer.  This checks the custom_logo setting before binding the blogname setting.  Resolves #4 